### PR TITLE
Added a Gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,7 +9,8 @@ var paths = {
   scripts: ['client/app/**/*.js'],
   html: ['client/app/**/*.html', 'client/index.html'],
   styles: ['client/styles/*.css'],
-  test: ['client/app/**/specs/*.js']
+  test: ['client/app/**/specs/*.js'],
+  server: 'server/server.js'
 };
 
 // start the dev server and then run browser-sync
@@ -24,7 +25,7 @@ gulp.task('start', ['serve'],function () {
 
 // start our node server using nodemon
 gulp.task('serve', function() {
-  nodemon({script: 'server/server.js', ignore: 'node_modules/**/*.js'});
+  nodemon({script: paths.server, ignore: 'node_modules/**/*.js'});
 });
 
 gulp.task('default', ['start']);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,31 @@
+var config = require('./server/config/config');
+var gulp = require('gulp');
+var nodemon = require('gulp-nodemon');
+var bs = require('browser-sync');
+var reload = bs.reload;
+
+// the paths to our app files
+var paths = {
+  scripts: ['client/app/**/*.js'],
+  html: ['client/app/**/*.html', 'client/index.html'],
+  styles: ['client/styles/*.css'],
+  test: ['client/app/**/specs/*.js']
+};
+
+// start the dev server and then run browser-sync
+gulp.task('start', ['serve'],function () {
+  bs({
+    notify: true,
+    injectChanges: true,
+    files: paths.scripts.concat(paths.html, paths.styles),
+    proxy: 'localhost:' + config.port
+  });
+});
+
+// start our node server using nodemon
+gulp.task('serve', function() {
+  nodemon({script: 'server/server.js', ignore: 'node_modules/**/*.js'});
+});
+
+gulp.task('default', ['start']);
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Minimalist Content Management System built on the mean stack",
   "main": "server/server.js",
   "scripts": {
-    "test": "node server.js"
+    "start": "gulp start"
   },
   "repository": {
     "type": "git",
@@ -25,5 +25,11 @@
     "passport": "^0.2.2",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^1.0.0"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "browser-sync": "^2.7.12",
+    "gulp-nodemon": "^2.0.3",
+    "gulp-shell": "^0.4.2"
   }
 }


### PR DESCRIPTION
Added a very simple gulpfile. By default it starts a nodemon server and a browser-sync session. When using browser-sync, the browser page-load tends to freeze up on startup. Just stop the browser page load, and refresh it. From then on it will accept all injected files/changes.
I also added a start script to npm so that you can run 'npm start' which basically runs gulp.